### PR TITLE
Add soldier unit prefab with swipe control and upgrades

### DIFF
--- a/Assets/Prefabs/Soldier.prefab
+++ b/Assets/Prefabs/Soldier.prefab
@@ -1,0 +1,40 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: Soldier
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  - component: {fileID: 1003}
+  - component: {fileID: 1004}
+  - component: {fileID: 1005}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &1001
+Transform:
+  m_GameObject: {fileID: 100000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &1002
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: 484a74c88a4a4fffae2f59af21095dd1, type: 3}
+  m_Name:
+--- !u!114 &1003
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: b8b5320d4fb44d1ba371db9ff601ddd7, type: 3}
+  m_Name:
+--- !u!114 &1004
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: 1b8eb5f686e548cb9bcb322a6a9df0af, type: 3}
+  m_Name:
+--- !u!65 &1005
+BoxCollider:
+  m_GameObject: {fileID: 100000}
+  m_IsTrigger: 0
+  m_Size: {x: 1, y: 1, z: 1}

--- a/Assets/Prefabs/Soldier.prefab.meta
+++ b/Assets/Prefabs/Soldier.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f2f8b3898e84afaa4c4563d434a7841
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Damage.cs
+++ b/Assets/Scripts/Damage.cs
@@ -1,0 +1,18 @@
+using UnityEngine;
+
+/// <summary>
+/// Applies damage to other objects on collision.
+/// </summary>
+public class Damage : MonoBehaviour
+{
+    public int damage = 10;
+
+    private void OnCollisionEnter(Collision collision)
+    {
+        Health target = collision.gameObject.GetComponent<Health>();
+        if (target != null)
+        {
+            target.TakeDamage(damage);
+        }
+    }
+}

--- a/Assets/Scripts/Damage.cs.meta
+++ b/Assets/Scripts/Damage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 1b8eb5f686e548cb9bcb322a6a9df0af
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Basic health component that tracks hit points and handles death.
+/// </summary>
+public class Health : MonoBehaviour
+{
+    public int maxHealth = 100;
+    [HideInInspector]
+    public int currentHealth;
+
+    private void Awake()
+    {
+        currentHealth = maxHealth;
+    }
+
+    /// <summary>
+    /// Apply damage to the component.
+    /// </summary>
+    public void TakeDamage(int amount)
+    {
+        currentHealth -= amount;
+        if (currentHealth <= 0)
+        {
+            Die();
+        }
+    }
+
+    /// <summary>
+    /// Heal the component by a given amount without exceeding max health.
+    /// </summary>
+    public void Heal(int amount)
+    {
+        currentHealth = Mathf.Min(maxHealth, currentHealth + amount);
+    }
+
+    private void Die()
+    {
+        Destroy(gameObject);
+    }
+}

--- a/Assets/Scripts/Health.cs.meta
+++ b/Assets/Scripts/Health.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8b5320d4fb44d1ba371db9ff601ddd7
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/PlayerInputController.cs
+++ b/Assets/Scripts/PlayerInputController.cs
@@ -1,0 +1,37 @@
+using UnityEngine;
+
+/// <summary>
+/// Detects swipe input and moves units on the conveyor belt.
+/// </summary>
+public class PlayerInputController : MonoBehaviour
+{
+    [Tooltip("Minimum swipe distance in pixels to trigger a lane change.")]
+    public float swipeThreshold = 50f;
+
+    private Vector2 startPosition;
+    private SoldierMovement selected;
+
+    private void Update()
+    {
+        if (Input.GetMouseButtonDown(0))
+        {
+            startPosition = Input.mousePosition;
+            Ray ray = Camera.main.ScreenPointToRay(startPosition);
+            if (Physics.Raycast(ray, out RaycastHit hit))
+            {
+                selected = hit.collider.GetComponent<SoldierMovement>();
+            }
+        }
+        else if (Input.GetMouseButtonUp(0) && selected != null)
+        {
+            Vector2 endPosition = Input.mousePosition;
+            Vector2 delta = endPosition - startPosition;
+            if (Mathf.Abs(delta.x) > swipeThreshold)
+            {
+                int direction = delta.x > 0 ? 1 : -1;
+                selected.MoveLane(direction);
+            }
+            selected = null;
+        }
+    }
+}

--- a/Assets/Scripts/PlayerInputController.cs.meta
+++ b/Assets/Scripts/PlayerInputController.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d4567f7d1efa4f16ba7f5d24209a9a3b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/SoldierMovement.cs
+++ b/Assets/Scripts/SoldierMovement.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+/// <summary>
+/// Handles forward motion and lane switching for a soldier unit.
+/// </summary>
+public class SoldierMovement : MonoBehaviour
+{
+    [Tooltip("Forward movement speed in units per second.")]
+    public float forwardSpeed = 2f;
+    [Tooltip("Horizontal distance moved per lane switch.")]
+    public float laneOffset = 1.5f;
+
+    private void Update()
+    {
+        transform.Translate(Vector3.forward * forwardSpeed * Time.deltaTime);
+    }
+
+    /// <summary>
+    /// Move the soldier horizontally across the belt by one lane in the given direction.
+    /// </summary>
+    public void MoveLane(int direction)
+    {
+        Vector3 position = transform.position;
+        position.x += laneOffset * direction;
+        transform.position = position;
+    }
+}

--- a/Assets/Scripts/SoldierMovement.cs.meta
+++ b/Assets/Scripts/SoldierMovement.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 484a74c88a4a4fffae2f59af21095dd1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/UnitUpgradeManager.cs
+++ b/Assets/Scripts/UnitUpgradeManager.cs
@@ -1,0 +1,48 @@
+using System.Collections.Generic;
+using UnityEngine;
+
+/// <summary>
+/// Manages unit upgrades and coin expenditure.
+/// </summary>
+public class UnitUpgradeManager : MonoBehaviour
+{
+    [Tooltip("Available coins for upgrading units.")]
+    public int coins;
+    [Tooltip("Base cost for the first upgrade.")]
+    public int baseUpgradeCost = 10;
+    [Tooltip("Multiplier applied to the cost for each subsequent level.")]
+    public float costMultiplier = 1.5f;
+
+    private readonly Dictionary<Health, int> upgradeLevels = new();
+
+    /// <summary>
+    /// Attempt to upgrade a unit's health and damage using coins.
+    /// </summary>
+    public bool TryUpgrade(Health health, Damage damage)
+    {
+        int level = 0;
+        if (upgradeLevels.TryGetValue(health, out int existing))
+        {
+            level = existing;
+        }
+        int cost = GetUpgradeCost(level);
+        if (coins < cost)
+        {
+            return false;
+        }
+        coins -= cost;
+        upgradeLevels[health] = level + 1;
+        health.maxHealth += 10;
+        health.currentHealth = health.maxHealth;
+        damage.damage += 2;
+        return true;
+    }
+
+    /// <summary>
+    /// Calculate the cost for the given upgrade level.
+    /// </summary>
+    public int GetUpgradeCost(int level)
+    {
+        return Mathf.RoundToInt(baseUpgradeCost * Mathf.Pow(costMultiplier, level));
+    }
+}

--- a/Assets/Scripts/UnitUpgradeManager.cs.meta
+++ b/Assets/Scripts/UnitUpgradeManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0c823911d4504ce9b049e71bfdde25d3
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- Add reusable Soldier prefab wiring movement, health and damage scripts
- Implement swipe-driven PlayerInputController and unit movement
- Introduce coin-based UnitUpgradeManager for stat upgrades

## Testing
- `dotnet test` *(fails: MSBUILD : error MSB1003: Specify a project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6896713cb26483219dda7b276fa021b3