### PR TITLE
Add boss prefab and spawner

### DIFF
--- a/Assets/Prefabs/Boss.prefab
+++ b/Assets/Prefabs/Boss.prefab
@@ -1,0 +1,125 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: Boss
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  - component: {fileID: 1003}
+  - component: {fileID: 1004}
+  - component: {fileID: 1005}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &1001
+Transform:
+  m_GameObject: {fileID: 100000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2001}
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+--- !u!114 &1002
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: c7353dc421e240f2b555c23aa86d813d, type: 3}
+  m_Name:
+  moveSpeed: 2
+  attack: {fileID: 1004}
+--- !u!114 &1003
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: b8b5320d4fb44d1ba371db9ff601ddd7, type: 3}
+  m_Name:
+  maxHealth: 500
+  currentHealth: 0
+--- !u!114 &1004
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: 6d1a9580582944c98b00da3b1bcc2a79, type: 3}
+  m_Name:
+  damage: 20
+  attackInterval: 1.5
+--- !u!65 &1005
+BoxCollider:
+  m_GameObject: {fileID: 100000}
+  m_IsTrigger: 0
+  m_Size: {x: 1, y: 1, z: 1}
+--- !u!1 &200000
+GameObject:
+  m_Name: HealthCanvas
+  m_Component:
+  - component: {fileID: 2001}
+  - component: {fileID: 2002}
+  - component: {fileID: 2003}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!224 &2001
+RectTransform:
+  m_GameObject: {fileID: 200000}
+  m_LocalPosition: {x: 0, y: 2, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 3001}
+  m_Father: {fileID: 1001}
+  m_RootOrder: 0
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 1, y: 0.2}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!223 &2002
+Canvas:
+  m_GameObject: {fileID: 200000}
+  m_RenderMode: 2
+  m_Camera: {fileID: 0}
+  m_PlaneDistance: 1
+  m_PixelPerfect: 0
+  m_ReceivesEvents: 1
+  m_OverrideSorting: 0
+  m_SortingBucketNormalizedSize: 0
+  m_AdditionalShaderChannelsFlag: 0
+  m_SortingLayerID: 0
+  m_SortingOrder: 0
+--- !u!114 &2003
+MonoBehaviour:
+  m_GameObject: {fileID: 200000}
+  m_Script: {fileID: 11500000, guid: a43b4c2ce0aa4d60ac49dc3e7537f5c9, type: 3}
+  m_Name:
+  health: {fileID: 0}
+  bar: {fileID: 3001}
+--- !u!1 &300000
+GameObject:
+  m_Name: Bar
+  m_Component:
+  - component: {fileID: 3001}
+  - component: {fileID: 3002}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &3001
+Transform:
+  m_GameObject: {fileID: 300000}
+  m_LocalPosition: {x: -0.5, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 0.2, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2001}
+  m_RootOrder: 0
+--- !u!212 &3002
+SpriteRenderer:
+  m_GameObject: {fileID: 300000}
+  m_Sprite: {fileID: 0}
+  m_Color: {r: 0, g: 1, b: 0, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 0

--- a/Assets/Prefabs/Boss.prefab.meta
+++ b/Assets/Prefabs/Boss.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 310a4f91bab64e7abf3a24d2e1617586
+PrefabImporter:
+  externalObjects: {}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -1,0 +1,29 @@
+using UnityEngine;
+
+/// <summary>
+/// Basic attack component that damages a target's Health at a fixed interval.
+/// </summary>
+public class Attack : MonoBehaviour
+{
+    public int damage = 20;
+    public float attackInterval = 1.5f;
+    private float lastAttackTime;
+
+    /// <summary>
+    /// Attempts to deal damage to the target's Health component.
+    /// </summary>
+    public void AttackTarget(GameObject target)
+    {
+        if (Time.time < lastAttackTime + attackInterval)
+        {
+            return;
+        }
+
+        Health targetHealth = target.GetComponent<Health>();
+        if (targetHealth != null)
+        {
+            targetHealth.TakeDamage(damage);
+            lastAttackTime = Time.time;
+        }
+    }
+}

--- a/Assets/Scripts/Attack.cs.meta
+++ b/Assets/Scripts/Attack.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6d1a9580582944c98b00da3b1bcc2a79
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/BossAI.cs
+++ b/Assets/Scripts/BossAI.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+
+/// <summary>
+/// Simple AI that moves towards the player and attacks when in range.
+/// </summary>
+[RequireComponent(typeof(Attack))]
+[RequireComponent(typeof(Health))]
+public class BossAI : MonoBehaviour
+{
+    public float moveSpeed = 2f;
+    public Attack attack;
+    private Transform target;
+
+    private void Awake()
+    {
+        if (attack == null)
+        {
+            attack = GetComponent<Attack>();
+        }
+    }
+
+    private void Start()
+    {
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        if (player != null)
+        {
+            target = player.transform;
+        }
+    }
+
+    private void Update()
+    {
+        if (target == null)
+        {
+            return;
+        }
+
+        Vector3 direction = (target.position - transform.position).normalized;
+        transform.position += direction * moveSpeed * Time.deltaTime;
+
+        attack.AttackTarget(target.gameObject);
+    }
+}

--- a/Assets/Scripts/BossAI.cs.meta
+++ b/Assets/Scripts/BossAI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c7353dc421e240f2b555c23aa86d813d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/BossSpawner.cs
+++ b/Assets/Scripts/BossSpawner.cs
@@ -1,0 +1,41 @@
+using UnityEngine;
+
+/// <summary>
+/// Spawns boss prefabs at set intervals and scales their health and damage.
+/// </summary>
+public class BossSpawner : MonoBehaviour
+{
+    public GameObject bossPrefab;
+    public float spawnInterval = 30f;
+    private float timer;
+    private int spawnCount = 0;
+
+    private void Update()
+    {
+        timer += Time.deltaTime;
+        if (timer >= spawnInterval)
+        {
+            SpawnBoss();
+            timer = 0f;
+        }
+    }
+
+    private void SpawnBoss()
+    {
+        spawnCount++;
+        GameObject boss = Instantiate(bossPrefab, transform.position, transform.rotation);
+
+        Health health = boss.GetComponent<Health>();
+        if (health != null)
+        {
+            health.maxHealth += spawnCount * 100;
+            health.currentHealth = health.maxHealth;
+        }
+
+        Attack attack = boss.GetComponent<Attack>();
+        if (attack != null)
+        {
+            attack.damage += spawnCount * 10;
+        }
+    }
+}

--- a/Assets/Scripts/BossSpawner.cs.meta
+++ b/Assets/Scripts/BossSpawner.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c4bc0d2166c94049903dab42cad71aee
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/HealthBar.cs
+++ b/Assets/Scripts/HealthBar.cs
@@ -1,0 +1,35 @@
+using UnityEngine;
+
+/// <summary>
+/// Scales a child transform to reflect the attached Health component.
+/// </summary>
+public class HealthBar : MonoBehaviour
+{
+    public Health health;
+    public Transform bar;
+    private float initialScaleX = 1f;
+
+    private void Awake()
+    {
+        if (health == null)
+        {
+            health = GetComponentInParent<Health>();
+        }
+
+        if (bar != null)
+        {
+            initialScaleX = bar.localScale.x;
+        }
+    }
+
+    private void Update()
+    {
+        if (health == null || bar == null || health.maxHealth <= 0)
+        {
+            return;
+        }
+
+        float scale = (float)health.currentHealth / health.maxHealth;
+        bar.localScale = new Vector3(initialScaleX * scale, bar.localScale.y, bar.localScale.z);
+    }
+}

--- a/Assets/Scripts/HealthBar.cs.meta
+++ b/Assets/Scripts/HealthBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a43b4c2ce0aa4d60ac49dc3e7537f5c9
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:


### PR DESCRIPTION
## Summary
- create Attack component for timed damage
- implement BossAI and spawner to summon tougher bosses
- add Boss prefab with world-space health bar canvas

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_6896758381f883218c7f16e83693a077