### PR TITLE
feat: add game manager for coins and upgrades

### DIFF
--- a/Assets/Scripts/GameManager.cs
+++ b/Assets/Scripts/GameManager.cs
@@ -1,0 +1,79 @@
+using UnityEngine;
+using UnityEngine.UI;
+
+/// <summary>
+/// Central game manager tracking score, coins and level progression.
+/// </summary>
+public class GameManager : MonoBehaviour
+{
+    public static GameManager Instance { get; private set; }
+
+    [Tooltip("UI text element showing the current coin balance.")]
+    public Text coinText;
+
+    [Tooltip("Current score accumulated by the player.")]
+    public int score;
+    [Tooltip("Current level number.")]
+    public int level = 1;
+    [Tooltip("Total coins available to spend.")]
+    public int coins;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        DontDestroyOnLoad(gameObject);
+        UpdateCoinUI();
+    }
+
+    /// <summary>
+    /// Increase the player's score.
+    /// </summary>
+    public void AddScore(int amount)
+    {
+        score += amount;
+    }
+
+    /// <summary>
+    /// Add coins and refresh the UI counter.
+    /// </summary>
+    public void AddCoins(int amount)
+    {
+        coins += amount;
+        UpdateCoinUI();
+    }
+
+    /// <summary>
+    /// Attempt to spend coins. Returns true if successful.
+    /// </summary>
+    public bool SpendCoins(int amount)
+    {
+        if (coins < amount)
+        {
+            return false;
+        }
+        coins -= amount;
+        UpdateCoinUI();
+        return true;
+    }
+
+    /// <summary>
+    /// Progress to the next level.
+    /// </summary>
+    public void AdvanceLevel()
+    {
+        level += 1;
+    }
+
+    private void UpdateCoinUI()
+    {
+        if (coinText != null)
+        {
+            coinText.text = coins.ToString();
+        }
+    }
+}

--- a/Assets/Scripts/GameManager.cs.meta
+++ b/Assets/Scripts/GameManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ccfce5fa15434df1a2d99e0c78d4e45e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData:
+  assetBundleName:
+  assetBundleVariant:

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -8,6 +8,10 @@ public class Health : MonoBehaviour
     public int maxHealth = 100;
     [HideInInspector]
     public int currentHealth;
+    [Tooltip("Coins awarded to the player when this unit dies.")]
+    public int coinValue = 0;
+    [Tooltip("Score awarded to the player when this unit dies.")]
+    public int scoreValue = 0;
 
     private void Awake()
     {
@@ -36,6 +40,11 @@ public class Health : MonoBehaviour
 
     private void Die()
     {
+        if (GameManager.Instance != null && CompareTag("Enemy"))
+        {
+            GameManager.Instance.AddCoins(coinValue);
+            GameManager.Instance.AddScore(scoreValue);
+        }
         Destroy(gameObject);
     }
 }

--- a/Assets/Scripts/UnitUpgradeManager.cs
+++ b/Assets/Scripts/UnitUpgradeManager.cs
@@ -6,8 +6,6 @@ using UnityEngine;
 /// </summary>
 public class UnitUpgradeManager : MonoBehaviour
 {
-    [Tooltip("Available coins for upgrading units.")]
-    public int coins;
     [Tooltip("Base cost for the first upgrade.")]
     public int baseUpgradeCost = 10;
     [Tooltip("Multiplier applied to the cost for each subsequent level.")]
@@ -26,11 +24,10 @@ public class UnitUpgradeManager : MonoBehaviour
             level = existing;
         }
         int cost = GetUpgradeCost(level);
-        if (coins < cost)
+        if (!GameManager.Instance.SpendCoins(cost))
         {
             return false;
         }
-        coins -= cost;
         upgradeLevels[health] = level + 1;
         health.maxHealth += 10;
         health.currentHealth = health.maxHealth;


### PR DESCRIPTION
## Summary
- create central `GameManager` tracking score, coins and level progression
- award coins on enemy death and show current balance on a UI text
- make `UnitUpgradeManager` spend coins from the `GameManager`

## Testing
- `dotnet test` *(fails: command not found)*
- `apt-get install -y dotnet-sdk-7.0` *(fails: package not found)*

------
https://chatgpt.com/codex/tasks/task_e_68967b8802908321b32d8c1eb8e76ab0