### PR TITLE
Integrate audio effects and animation blending

### DIFF
--- a/Assets/Animations/Attack.anim
+++ b/Assets/Animations/Attack.anim
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_Name: Attack
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 0
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Attack.anim.meta
+++ b/Assets/Animations/Attack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 498f0e4e28074275813b0f5442ecdaa2
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Death.anim
+++ b/Assets/Animations/Death.anim
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_Name: Death
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 0
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Death.anim.meta
+++ b/Assets/Animations/Death.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2b026063e8de4ac49f7969a2670f5f44
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Soldier.controller
+++ b/Assets/Animations/Soldier.controller
@@ -1,0 +1,71 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!91 &9100000
+AnimatorController:
+  m_Name: Soldier
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: Speed
+    m_Type: 1
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Attack
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  - m_Name: Death
+    m_Type: 9
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 9100000}
+  m_LayerArray:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: 110000}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_Blending: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Weight: 1
+    m_SyncedLayerIndex: -1
+    m_IKPass: 0
+    m_Culling: 0
+    m_DefaultWeight: 0
+    m_AvatarMask: {fileID: 0}
+    m_Speed: 1
+    m_StateMachineBehaviour: 
+    m_Transitions: []
+--- !u!110 &110000
+AnimatorStateMachine:
+  m_Name: Base Layer
+  m_DefaultState: {fileID: 110001}
+  m_ChildStates:
+  - m_State: {fileID: 110001}
+  - m_State: {fileID: 110002}
+  - m_State: {fileID: 110003}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_ExitTransitions: []
+  m_StateMachineTransitions: {}
+--- !u!110 &110001
+AnimatorState:
+  m_Name: Walk
+  m_Speed: 1
+  m_Motion: {fileID: 7400000, guid: 3ed1c36578db4815a2d4986de409ad8c, type: 3}
+--- !u!110 &110002
+AnimatorState:
+  m_Name: Attack
+  m_Speed: 1
+  m_Motion: {fileID: 7400000, guid: 498f0e4e28074275813b0f5442ecdaa2, type: 3}
+--- !u!110 &110003
+AnimatorState:
+  m_Name: Death
+  m_Speed: 1
+  m_Motion: {fileID: 7400000, guid: 2b026063e8de4ac49f7969a2670f5f44, type: 3}

--- a/Assets/Animations/Soldier.controller.meta
+++ b/Assets/Animations/Soldier.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c85f7221ccaf4adf80d53ea64104cd1a
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Walk.anim
+++ b/Assets/Animations/Walk.anim
@@ -1,0 +1,47 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_Name: Walk
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves: []
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings: []
+    pptrCurveMapping: []
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_StartTime: 0
+    m_StopTime: 1
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 0
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Walk.anim.meta
+++ b/Assets/Animations/Walk.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ed1c36578db4815a2d4986de409ad8c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/README.md
+++ b/Assets/Audio/README.md
@@ -1,0 +1,3 @@
+# Audio Assets
+
+Binary audio clips have been removed from version control. Add your own audio files (e.g. `.wav`) to this folder and assign them in the Unity editor.

--- a/Assets/Audio/README.md.meta
+++ b/Assets/Audio/README.md.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: abcdef1234567890abcdef1234567890
+TextScriptImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/AudioManager.prefab
+++ b/Assets/Prefabs/AudioManager.prefab
@@ -1,0 +1,25 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: AudioManager
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &1001
+Transform:
+  m_GameObject: {fileID: 100000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!114 &1002
+MonoBehaviour:
+  m_GameObject: {fileID: 100000}
+  m_Script: {fileID: 11500000, guid: deed579c94024a9cb41c36c17194b850, type: 3}
+  m_Name:
+  shootClip: {fileID: 8300000, guid: 95d6a0730cef42149a98b54d7d376bcb, type: 3}
+  explosionClip: {fileID: 8300000, guid: 5768f563aa9443a49bab9a12f49bdc5d, type: 3}
+  upgradeClip: {fileID: 8300000, guid: da4387c13e4b4e3a9ec735d8dc19c6f2, type: 3}

--- a/Assets/Prefabs/AudioManager.prefab.meta
+++ b/Assets/Prefabs/AudioManager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ed23240332a74d54afe362c8486ba42b
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Boss.prefab
+++ b/Assets/Prefabs/Boss.prefab
@@ -36,6 +36,9 @@ MonoBehaviour:
   m_Name:
   maxHealth: 500
   currentHealth: 0
+  coinValue: 0
+  scoreValue: 0
+  deathEffect: {fileID: 1002, guid: 6f8c06f59d0e476091afb99657056178, type: 3}
 --- !u!114 &1004
 MonoBehaviour:
   m_GameObject: {fileID: 100000}
@@ -43,6 +46,7 @@ MonoBehaviour:
   m_Name:
   damage: 20
   attackInterval: 1.5
+  shootEffect: {fileID: 1002, guid: c91f2946d9c24e5896fa5cb41024bd92, type: 3}
 --- !u!65 &1005
 BoxCollider:
   m_GameObject: {fileID: 100000}

--- a/Assets/Prefabs/ExplosionEffect.prefab
+++ b/Assets/Prefabs/ExplosionEffect.prefab
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: ExplosionEffect
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &1001
+Transform:
+  m_GameObject: {fileID: 100000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!198 &1002
+ParticleSystem:
+  m_GameObject: {fileID: 100000}

--- a/Assets/Prefabs/ExplosionEffect.prefab.meta
+++ b/Assets/Prefabs/ExplosionEffect.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 6f8c06f59d0e476091afb99657056178
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/ShootEffect.prefab
+++ b/Assets/Prefabs/ShootEffect.prefab
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: ShootEffect
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &1001
+Transform:
+  m_GameObject: {fileID: 100000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!198 &1002
+ParticleSystem:
+  m_GameObject: {fileID: 100000}

--- a/Assets/Prefabs/ShootEffect.prefab.meta
+++ b/Assets/Prefabs/ShootEffect.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c91f2946d9c24e5896fa5cb41024bd92
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Soldier.prefab
+++ b/Assets/Prefabs/Soldier.prefab
@@ -9,6 +9,7 @@ GameObject:
   - component: {fileID: 1003}
   - component: {fileID: 1004}
   - component: {fileID: 1005}
+  - component: {fileID: 1006}
   m_Layer: 0
   m_TagString: Untagged
   m_Active: 1
@@ -28,6 +29,11 @@ MonoBehaviour:
   m_GameObject: {fileID: 100000}
   m_Script: {fileID: 11500000, guid: b8b5320d4fb44d1ba371db9ff601ddd7, type: 3}
   m_Name:
+  maxHealth: 100
+  currentHealth: 0
+  coinValue: 0
+  scoreValue: 0
+  deathEffect: {fileID: 1002, guid: 6f8c06f59d0e476091afb99657056178, type: 3}
 --- !u!114 &1004
 MonoBehaviour:
   m_GameObject: {fileID: 100000}
@@ -38,3 +44,14 @@ BoxCollider:
   m_GameObject: {fileID: 100000}
   m_IsTrigger: 0
   m_Size: {x: 1, y: 1, z: 1}
+--- !u!95 &1006
+Animator:
+  m_GameObject: {fileID: 100000}
+  m_Controller: {fileID: 9100000, guid: c85f7221ccaf4adf80d53ea64104cd1a, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage:
+  m_HasTransformHierarchy: 0
+  m_KeepAnimatorControllerStateOnDisable: 0

--- a/Assets/Prefabs/UpgradeEffect.prefab
+++ b/Assets/Prefabs/UpgradeEffect.prefab
@@ -1,0 +1,20 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &100000
+GameObject:
+  m_Name: UpgradeEffect
+  m_Component:
+  - component: {fileID: 1001}
+  - component: {fileID: 1002}
+  m_Layer: 0
+  m_TagString: Untagged
+  m_Active: 1
+--- !u!4 &1001
+Transform:
+  m_GameObject: {fileID: 100000}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+--- !u!198 &1002
+ParticleSystem:
+  m_GameObject: {fileID: 100000}

--- a/Assets/Prefabs/UpgradeEffect.prefab.meta
+++ b/Assets/Prefabs/UpgradeEffect.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 49c04d3418ed4c1d81882e4cc7ca5f4f
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Attack.cs
+++ b/Assets/Scripts/Attack.cs
@@ -8,6 +8,14 @@ public class Attack : MonoBehaviour
     public int damage = 20;
     public float attackInterval = 1.5f;
     private float lastAttackTime;
+    [Tooltip("Particle effect played when attacking.")]
+    public ParticleSystem shootEffect;
+    private Animator animator;
+
+    private void Awake()
+    {
+        animator = GetComponent<Animator>();
+    }
 
     /// <summary>
     /// Attempts to deal damage to the target's Health component.
@@ -24,6 +32,18 @@ public class Attack : MonoBehaviour
         {
             targetHealth.TakeDamage(damage);
             lastAttackTime = Time.time;
+            if (animator != null)
+            {
+                animator.SetTrigger("Attack");
+            }
+            if (AudioManager.Instance != null)
+            {
+                AudioManager.Instance.PlayShoot();
+            }
+            if (shootEffect != null)
+            {
+                Instantiate(shootEffect, transform.position, Quaternion.identity);
+            }
         }
     }
 }

--- a/Assets/Scripts/AudioManager.cs
+++ b/Assets/Scripts/AudioManager.cs
@@ -1,0 +1,61 @@
+using UnityEngine;
+
+/// <summary>
+/// Centralised audio playback for common game events.
+/// </summary>
+public class AudioManager : MonoBehaviour
+{
+    public static AudioManager Instance { get; private set; }
+
+    [Tooltip("Sound played when a unit shoots")]
+    public AudioClip shootClip;
+    [Tooltip("Sound played on explosions")]
+    public AudioClip explosionClip;
+    [Tooltip("Sound played on upgrades")]
+    public AudioClip upgradeClip;
+
+    private AudioSource audioSource;
+
+    private void Awake()
+    {
+        if (Instance != null && Instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        Instance = this;
+        audioSource = gameObject.AddComponent<AudioSource>();
+    }
+
+    /// <summary>
+    /// Play the shooting sound effect.
+    /// </summary>
+    public void PlayShoot()
+    {
+        PlayClip(shootClip);
+    }
+
+    /// <summary>
+    /// Play the explosion sound effect.
+    /// </summary>
+    public void PlayExplosion()
+    {
+        PlayClip(explosionClip);
+    }
+
+    /// <summary>
+    /// Play the upgrade sound effect.
+    /// </summary>
+    public void PlayUpgrade()
+    {
+        PlayClip(upgradeClip);
+    }
+
+    private void PlayClip(AudioClip clip)
+    {
+        if (clip != null)
+        {
+            audioSource.PlayOneShot(clip);
+        }
+    }
+}

--- a/Assets/Scripts/AudioManager.cs.meta
+++ b/Assets/Scripts/AudioManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: deed579c94024a9cb41c36c17194b850
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Health.cs
+++ b/Assets/Scripts/Health.cs
@@ -12,10 +12,14 @@ public class Health : MonoBehaviour
     public int coinValue = 0;
     [Tooltip("Score awarded to the player when this unit dies.")]
     public int scoreValue = 0;
+    [Tooltip("Particle effect played on death.")]
+    public ParticleSystem deathEffect;
+    private Animator animator;
 
     private void Awake()
     {
         currentHealth = maxHealth;
+        animator = GetComponent<Animator>();
     }
 
     /// <summary>
@@ -44,6 +48,18 @@ public class Health : MonoBehaviour
         {
             GameManager.Instance.AddCoins(coinValue);
             GameManager.Instance.AddScore(scoreValue);
+        }
+        if (AudioManager.Instance != null)
+        {
+            AudioManager.Instance.PlayExplosion();
+        }
+        if (animator != null)
+        {
+            animator.SetTrigger("Death");
+        }
+        if (deathEffect != null)
+        {
+            Instantiate(deathEffect, transform.position, Quaternion.identity);
         }
         Destroy(gameObject);
     }

--- a/Assets/Scripts/SoldierMovement.cs
+++ b/Assets/Scripts/SoldierMovement.cs
@@ -10,9 +10,20 @@ public class SoldierMovement : MonoBehaviour
     [Tooltip("Horizontal distance moved per lane switch.")]
     public float laneOffset = 1.5f;
 
+    private Animator animator;
+
+    private void Awake()
+    {
+        animator = GetComponent<Animator>();
+    }
+
     private void Update()
     {
         transform.Translate(Vector3.forward * forwardSpeed * Time.deltaTime);
+        if (animator != null)
+        {
+            animator.SetFloat("Speed", forwardSpeed);
+        }
     }
 
     /// <summary>

--- a/Assets/Scripts/UnitUpgradeManager.cs
+++ b/Assets/Scripts/UnitUpgradeManager.cs
@@ -10,6 +10,8 @@ public class UnitUpgradeManager : MonoBehaviour
     public int baseUpgradeCost = 10;
     [Tooltip("Multiplier applied to the cost for each subsequent level.")]
     public float costMultiplier = 1.5f;
+    [Tooltip("Particle effect played upon successful upgrade.")]
+    public ParticleSystem upgradeEffect;
 
     private readonly Dictionary<Health, int> upgradeLevels = new();
 
@@ -32,6 +34,14 @@ public class UnitUpgradeManager : MonoBehaviour
         health.maxHealth += 10;
         health.currentHealth = health.maxHealth;
         damage.damage += 2;
+        if (AudioManager.Instance != null)
+        {
+            AudioManager.Instance.PlayUpgrade();
+        }
+        if (upgradeEffect != null)
+        {
+            Instantiate(upgradeEffect, health.transform.position, Quaternion.identity);
+        }
         return true;
     }
 


### PR DESCRIPTION
## Summary
- Centralize audio playback via an `AudioManager` script exposing shoot, explosion, and upgrade clips for reuse across gameplay events
- Trigger particle effects and animation parameters for attacks, deaths, upgrades, and soldier movement
- Remove committed binary audio assets and document how to supply local clips in `Assets/Audio/README.md`

## Testing
- `dotnet test` (MSBUILD: Specify a project or solution file. The current working directory does not contain a project or solution file.)

------
https://chatgpt.com/codex/tasks/task_e_6896ef53de988321aac46a0f92fbd8d4